### PR TITLE
Fixed bug in the example code

### DIFF
--- a/doc_source/tutorial-continue-new.md
+++ b/doc_source/tutorial-continue-new.md
@@ -269,7 +269,7 @@ This excerpt of your state machine shows the `Restart` `[Task](amazon-states-lan
              "Type": "Choice",
              "Choices": [
                {
-                 "Variable": "$.restart.count",
+                 "Variable": "$.iterator.count",
                  "NumericGreaterThan": 0,
                  "Next": "Restart"
                }

--- a/doc_source/tutorial-continue-new.md
+++ b/doc_source/tutorial-continue-new.md
@@ -269,7 +269,7 @@ This excerpt of your state machine shows the `Restart` `[Task](amazon-states-lan
              "Type": "Choice",
              "Choices": [
                {
-                 "Variable": "$.iterator.count",
+                 "Variable": "$.restart.executionCount",
                  "NumericGreaterThan": 0,
                  "Next": "Restart"
                }


### PR DESCRIPTION
*Issue #, if available:*
The path to the variable was wrong.

*Description of changes:*
Replaced `restart` to `iterator`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
