### PR TITLE
Add clarification that functions are not supported

### DIFF
--- a/doc_source/amazon-states-language-input-output-processing.md
+++ b/doc_source/amazon-states-language-input-output-processing.md
@@ -11,6 +11,7 @@ In Amazon States Language, a *path* is a string beginning with `$` that you can 
 A *reference path* is a path whose syntax is limited in such a way that it can identify only a single node in a JSON structure:
 + You can access object fields using only dot \(`.`\) and square bracket \(`[ ]`\) notation\.
 + The operators `@ .. , : ? *` aren't supported\.
++ Functions such as `length()` aren't supported\.
 
 For example, state input data contains the following values:
 


### PR DESCRIPTION
I did run into this issue as I was trying to use the length of an array is the `inputPath`, resulting the in the following error.

```
An error occurred while executing the state 'MyState' (entered at the event id #4). Invalid path '$.list.length()' : Property ['length()'] not found in path $['list']
```

Even though the current documentation technically covers it by stating:

>  …that it can identify only a single node in…

I thought it may still be helpful to make it explicit that functions as defined in the JsonPath spec are not supported at all.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.