### PR TITLE
Fixed typo, 'bases' to 'based'

### DIFF
--- a/doc_source/sfn-local-lambda.md
+++ b/doc_source/sfn-local-lambda.md
@@ -30,7 +30,7 @@ Before installing the AWS SAM CLI, you will need to install the AWS CLI and Dock
 
    1.  [Test the Application Locally](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-quick-start.html#gs-ex1-test-locally) 
 
-   This will create a `sam-app` directory, and will build an environment that includes a Python\-bases hello world Lambda function\.
+   This will create a `sam-app` directory, and will build an environment that includes a Python\-based hello world Lambda function\.
 
 ## Step 2: Test Lambda Local<a name="test-local-lambda"></a>
 


### PR DESCRIPTION
*Issue #, if available:* Fixed typo in documentation.

*Description of changes:*
'python-bases' to 'python-based'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
