### PR TITLE
use correct casing in code example

### DIFF
--- a/doc_source/connectors-batch.md
+++ b/doc_source/connectors-batch.md
@@ -39,7 +39,8 @@ The following includes a `Task` state that submits an AWS Batch job and waits fo
        "JobQueue": "SecondaryQueue",
        "Parameters.$": "$.batchjob.parameters",
        "ContainerOverrides": {
-          "vcpus": 4
+          "Vcpus": 4,
+          "Memory": 16000
         }
      },
      "End": true


### PR DESCRIPTION
*Description of changes:*
use PascalCase for `ContainerOverrides` properties to be consistent with the note above and what the state machine validator expects.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
