### PR TITLE
Update tutorial-cloudwatch-events-s3.md

### DIFF
--- a/doc_source/tutorial-cloudwatch-events-s3.md
+++ b/doc_source/tutorial-cloudwatch-events-s3.md
@@ -76,6 +76,8 @@ You must configure CloudWatch Events in the same AWS Region as the Amazon S3 buc
 1. For **Event Type**, choose **Object Level Operations**\.
 
 1. Choose **Specific operation\(s\)**, and then choose **PutObject**\.
+**Note**  
+If the object size is bigger than the multipart threshold(default is 8MB) used in the PutObject operation, the CloudTtrail API logged will be **CompleteMultipartUpload** instead of PutObject\.
 
 1. Choose **Specific bucket\(s\) by name** and enter the bucket name you created in Step 1 \(`username-sfn-tutorial`\)\.
 


### PR DESCRIPTION
*Issue #24  *

*Description of changes:*
Adding new new information about the situation where putting big objects into S3 that may result in non invocation of the Step Functions due to the Multipart Upload of S3. By default the operation PutObject will use multipart upload if objects are bigger than the 8MB. The user can specify on the request the multipart threshold on the request as well


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
