### PR TITLE
Fixed misleading info of running multiple commands

### DIFF
--- a/doc_source/connect-ecs.md
+++ b/doc_source/connect-ecs.md
@@ -62,14 +62,25 @@ The following includes a `Task` state that runs an Amazon ECS task and waits for
 
 The `"Command.$": "$.commands"` line in `ContainerOverrides` passes the commands from the state input to the container\.
 
-For the previous example, if the input to the execution is the following\.
+For example, to run a single command with two parameters, the input to the execution is the following\.
 
 ```
 {
   "commands": [
     "test command 1",
-    "test command 2",
-    "test command 3"
+    "parameter 1",
+    "parameter 2"
+  ]
+}
+```
+Another example for running multiple commands within a shell, the input to the execution is the following\.
+
+```
+{
+  "commands": [
+    "sh",
+    "-c",
+    "test command 1; test command 2; test command 3;"
   ]
 }
 ```


### PR DESCRIPTION
Multiple commands can't be run with the original provided input format. It is not supported in Docker. Corrected the misleading information and added a workaround.

*Issue #, if available:*

*Description of changes:*
Based on Docker Doc [1] and Docker API Doc [2], Docker can't run multiple commands with CMD. One workaround is to wrap multiple commands into a parameter to be run by a shell [3]. This is also align with ECS doc [4].

[1] https://docs.docker.com/engine/reference/builder/#cmd
[2] https://docs.docker.com/engine/api/v1.38/#operation/ContainerCreate
[3] https://stackoverflow.com/questions/28490874/docker-run-image-multiple-commands
[4] refer to "command" in https://docs.aws.amazon.com/AmazonECS/latest/userguide/task_definition_parameters.html#container_definition_environment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
