### PR TITLE
Update amazon-states-language-wait-state.md

### DIFF
--- a/doc_source/amazon-states-language-wait-state.md
+++ b/doc_source/amazon-states-language-wait-state.md
@@ -32,7 +32,7 @@ The following `Wait` state introduces a 10\-second delay into a state machine\.
 }
 ```
 
-In the next example, the `Wait` state waits until an absolute time: March 14th, 2016, at 1:59 PM UTC\.
+In the next example, the `Wait` state waits until an absolute time: March 14th, 2016, at 1:59 AM UTC\.
 
 ```
 "wait_until" : {


### PR DESCRIPTION
AM PM was incorrect given the time stamp entry (1pm=1300 and 1am=0100

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
