### PR TITLE
Updated nodejs8.10 to nodejs12.x

### DIFF
--- a/doc_source/tutorial-human-approval.md
+++ b/doc_source/tutorial-human-approval.md
@@ -289,7 +289,7 @@ Resources:
       FunctionName: LambdaApprovalFunction
       Handler: index.handler
       Role: !GetAtt "LambdaApiGatewayIAMRole.Arn"
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
 
   LambdaApiGatewayInvoke:
     Type: "AWS::Lambda::Permission"
@@ -391,7 +391,7 @@ Resources:
     Properties:
       Handler: "index.lambda_handler"
       Role: !GetAtt LambdaSendEmailExecutionRole.Arn
-      Runtime: "nodejs8.10"
+      Runtime: "nodejs12.x"
       Timeout: "25"
       Code:
         ZipFile:


### PR DESCRIPTION
Because nodejs8.10 is not supported anymore the creation of the stack failed. 
When I changed it to nodejs12.x the stack could be created and I could successfully execute the step functions. All state transitions were tested.


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
