### PR TITLE
Fixing Retry block for Nested State Machine

### DIFF
--- a/doc_source/concepts-nested-workflows.md
+++ b/doc_source/concepts-nested-workflows.md
@@ -16,16 +16,16 @@ Step Functions can start these workflow executions by calling its own API as an 
       "StateMachineArn":"arn:aws:states:us-east-1:123456789012:stateMachine:HelloWorld",
       "Input":{  
          "Comment":"Hello world!"
-      },
-      "Retry":[  
-         {  
-            "ErrorEquals":[  
-               "StepFunctions.ExecutionLimitExceeded"
-            ]
-         }
-      ],
-      "End":true
-   }
+      }
+   },
+   "Retry":[  
+      {  
+         "ErrorEquals":[  
+            "StepFunctions.ExecutionLimitExceeded"
+         ]
+      }
+   ],
+   "End":true
 }
 ```
 


### PR DESCRIPTION
Fixing the 'Retry' block for nested State Machine documentation. Originally the documentation had the retry block within the parameter block but it should be outside the  parameter block in the "Task" block.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
