### PR TITLE
add: Task State Example with ResultPath

### DIFF
--- a/doc_source/connect-stepfunctions.md
+++ b/doc_source/connect-stepfunctions.md
@@ -49,6 +49,39 @@ The following includes a `Task` state that starts an execution of another state 
    "End":true
 }
 ```
+The following includes multiple `Task` states that start an execution with different path values against the same state machine\.
+
+```
+{
+    "StartAt": "ProcessFirstMessage",
+    "States": {
+        "ProcessFirstMessage": {
+            "Type": "Task",
+            "Resource":"arn:aws:states:::states:startExecution.sync:2",
+            "Parameters":{
+                "Input": { 
+                    "HelloWorld.$": "$.FirstMessage.Content"
+                },
+            "StateMachineArn":"arn:aws:states:us-east-1:123456789012:stateMachine:HelloWorld"
+        },
+        "ResultPath": "$.Reponse",
+        "Next":"ProcessSecondMessage"
+        },
+        "ProcessSecondMessage": {
+            "Type": "Task",
+            "Resource":"arn:aws:states:::states:startExecution.sync:2",
+            "Parameters":{
+                "Input":{
+                    "HelloWorld.$": "$.SecondMessage.Content"
+                },
+                "StateMachineArn":"arn:aws:states:us-east-1:123456789012:stateMachine:HelloWorld"
+        },
+        "ResultPath": "$.Reponse",
+        "End":true   
+        }
+    }
+}
+```
 
 The following includes a `Task` state that implements the [callback](connect-to-resource.md#connect-wait-token) service integration pattern\.
 


### PR DESCRIPTION
*Description of changes:*

The following change includes multiple Task states that start an execution with different path values against the same state machine in order to re-use step machine across multiple steps.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
