### PR TITLE
doc: fix the format when error occured

### DIFF
--- a/doc_source/connect-api-gateway.md
+++ b/doc_source/connect-api-gateway.md
@@ -198,8 +198,8 @@ An example response:
 ## Error handling<a name="connect-api-gateway-errors"></a>
 
 When an error occurs, an `error` and `cause` is returned as follows: 
-+ If the HTTP status code is available, then the error will be returned in the format `APIGateway.<HTTP Status Code>`\.
-+ If the HTTP status code is not available, then the error will be returned in the format `APIGateway.<Exception>`\.
++ If the HTTP status code is available, then the error will be returned in the format `ApiGateway.<HTTP Status Code>`\.
++ If the HTTP status code is not available, then the error will be returned in the format `ApiGateway.<Exception>`\.
 
 In both cases, the `cause` is returned as a string\.
 
@@ -207,7 +207,7 @@ The following example shows a response where an error has occurred:
 
 ```
 {
-    "error": "APIGateway.403", 
+    "error": "ApiGateway.403", 
     "cause": "{\"message\":\"Missing Authentication Token\"}"
 }
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The string returned in case of an error seems to be `ApiGateway` instead of `APIGateway`.

I attach a screenshot of the execution in which the error occurred.

<img src="https://user-images.githubusercontent.com/491754/113481095-9c39aa80-94d2-11eb-94cf-dd71185b70a8.png" width="640">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
