### PR TITLE
fix typo in SageMaker CreateLabelingJob

### DIFF
--- a/doc_source/connect-sagemaker.md
+++ b/doc_source/connect-sagemaker.md
@@ -236,7 +236,7 @@ The following includes a `Task` state that creates an Amazon SageMaker labeling 
 
 ```
 {
-  "StartAt": "SageMaker CreaateLabelingJob",
+  "StartAt": "SageMaker CreateLabelingJob",
   "TimeoutSeconds": 3600,
   "States": {
     "SageMaker CreaateLabelingJob": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
Remove duplicate `a` in `SageMaker CreaateLabelingJob` 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
