### PR TITLE
Improve $$.StateMachine.name description, example

### DIFF
--- a/doc_source/input-output-contextobject.md
+++ b/doc_source/input-output-contextobject.md
@@ -25,7 +25,8 @@ The context object includes information about the state machine, state, executio
         "RetryCount": Number
     },
     "StateMachine": {
-        "Id": "String"
+        "Id": "String",
+        "Name": "String"
     },
     "Task": {
         "Token": "String"
@@ -55,7 +56,7 @@ Content from a running execution includes specifics in the following format\.
     },
     "StateMachine": {
         "Id": "arn:aws:states:us-east-1:123456789012:stateMachine:stateMachineName",
-        "Name": "name"
+        "Name": "stateMachineName"
     },
     "Task": {
         "Token": "h7XRiCdLtd/83p1E0dMccoxlzFhglsdkzpK9mBVKZsp7d9yrT1W"


### PR DESCRIPTION
Improve documentation for the $$.StateMachine.name Context Object parameter.  It exists and works, but wasn't documented properly.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
