### PR TITLE
Add missing field names to context object

### DIFF
--- a/doc_source/input-output-contextobject.md
+++ b/doc_source/input-output-contextobject.md
@@ -17,6 +17,8 @@ The context object includes information about the state machine, state, executio
     "Execution": {
         "Id": "String",
         "Input": {},
+        "Name": "String",
+        "RoleArn": "String",
         "StartTime": "Format: ISO 8601"
     },
     "State": {
@@ -25,7 +27,8 @@ The context object includes information about the state machine, state, executio
         "RetryCount": Number
     },
     "StateMachine": {
-        "Id": "String"
+        "Id": "String",
+        "Name": "String"
     },
     "Task": {
         "Token": "String"


### PR DESCRIPTION
These are fields that I have used before and are listed in the examples below.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
