### PR TITLE
Fix intro text for Wait state's `Timestamp` example

### DIFF
--- a/doc_source/amazon-states-language-wait-state.md
+++ b/doc_source/amazon-states-language-wait-state.md
@@ -33,7 +33,7 @@ The following `Wait` state introduces a 10\-second delay into a state machine\.
 }
 ```
 
-In the next example, the `Wait` state waits until an absolute time: March 14, 2016, at 1:59 PM UTC\.
+In the next example, the `Wait` state waits until an absolute time: March 14, 2016, at 1:59 AM UTC\.
 
 ```
 "wait_until" : {


### PR DESCRIPTION
*Description of changes:*

Corrects intro text for a `Timestamp` field example for the `Wait` state. "2016-03-14T01:59:00Z" is 1:59 **AM**, not PM.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
