### PR TITLE
Update amazon-states-language-paths.md

### DIFF
--- a/doc_source/amazon-states-language-paths.md
+++ b/doc_source/amazon-states-language-paths.md
@@ -12,7 +12,7 @@ A *reference path* is a path whose syntax is limited in such a way that it can i
 + Functions such as `length()` aren't supported\.
 + Lexical (non-symbol) operators such as `subsetof` aren't supported\.
 + Filtering by regular expression or by referencing another value in the JSON structure isn't supported\.
-+ The `@` operator, matching the current node being processed in a filter, does not match scalar values, only objects\.
++ The `@` operator, matching the current node being processed in a filter, does not match scalar values. It only matches objects\.
 
 For example, if state input data contains the following values:
 
@@ -36,4 +36,4 @@ $.car.cdr => true
 $.jar[?(@.a >= 5)] => [{"a": 5}, {"a": 7}]
 ```
 
-Certain states use paths and reference paths to control the flow of a state machine or configure a state's settings or options\. For more information see [Modeling workflow input and output path processing with data flow simulator](https://aws.amazon.com/blogs/compute/modeling-workflow-input-output-path-processing-with-data-flow-simulator/) and [Using JSONPath effectively in AWS Step Functions](https://aws.amazon.com/blogs/compute/using-jsonpath-effectively-in-aws-step-functions/)\.
+Certain states use paths and reference paths to control the flow of a state machine or configure a state's settings or options\. For more information, see [Modeling workflow input and output path processing with data flow simulator](https://aws.amazon.com/blogs/compute/modeling-workflow-input-output-path-processing-with-data-flow-simulator/) and [Using JSONPath effectively in AWS Step Functions](https://aws.amazon.com/blogs/compute/using-jsonpath-effectively-in-aws-step-functions/)\.

--- a/doc_source/amazon-states-language-paths.md
+++ b/doc_source/amazon-states-language-paths.md
@@ -9,8 +9,10 @@ You can also specify a JSON node of the input or the context object by using pat
 
 A *reference path* is a path whose syntax is limited in such a way that it can identify only a single node in a JSON structure:
 + You can access object fields using only dot \(`.`\) and square bracket \(`[ ]`\) notation\.
-+ The operators `@ .. , : ? *` aren't supported\.
 + Functions such as `length()` aren't supported\.
++ Lexical (non-symbol) operators such as `subsetof` aren't supported\.
++ Filtering by regular expression or by referencing another value in the JSON structure isn't supported\.
++ The `@` operator, matching the current node being processed in a filter, does not match scalar values, only objects\.
 
 For example, if state input data contains the following values:
 
@@ -20,7 +22,8 @@ For example, if state input data contains the following values:
     "bar": ["a", "b", "c"],
     "car": {
         "cdr": true
-    }
+    },
+    "jar": [{"a": 1}, {"a": 5}, {"a": 2}, {"a": 7}, {"a": 3}]
 }
 ```
 
@@ -30,6 +33,7 @@ The following reference paths would return the following\.
 $.foo => 123
 $.bar => ["a", "b", "c"]
 $.car.cdr => true
+$.jar[?(@.a >= 5)] => [{"a": 5}, {"a": 7}]
 ```
 
-Certain states use paths and reference paths to control the flow of a state machine or configure a state's settings or options\.
+Certain states use paths and reference paths to control the flow of a state machine or configure a state's settings or options\. For more information see [Modeling workflow input and output path processing with data flow simulator](https://aws.amazon.com/blogs/compute/modeling-workflow-input-output-path-processing-with-data-flow-simulator/) and [Using JSONPath effectively in AWS Step Functions](https://aws.amazon.com/blogs/compute/using-jsonpath-effectively-in-aws-step-functions/)\.


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Updating to remove statement that filter operators don't work (they have worked since at least April 2021) and to flesh out other limitations, and to link to a couple of AWS blog posts that have some more examples. I tested the various JsonPath filters in the data flow simulator.

EDIT: See [#47](https://github.com/awsdocs/aws-step-functions-developer-guide/issues/47) 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
