### PR TITLE
Update connect-ecs.md

### DIFF
--- a/doc_source/connect-ecs.md
+++ b/doc_source/connect-ecs.md
@@ -14,7 +14,8 @@ The \.sync integration pattern is available\.
 Supported Amazon ECS/Fargate APIs and syntax:
 
 **Note**  
-Parameters in Step Functions are expressed in `PascalCase`, even when the native service API is `camelCase`\. 
+Parameters in Step Functions are expressed in `PascalCase`, even when the native service API is `camelCase`\. This holds for the contents of Parameters whose types are non-primitives. For example, consider `PlacementStrategy`, which is an Array of [PlacementStrategy](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PlacementStrategy.html) objects. The properties of those objects should also be `PascalCase`.
+
 + [https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html) starts a new task using the specified task definition\.
   + [Request syntax](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html#API_RunTask_RequestSyntax)
   + Supported parameters: 


### PR DESCRIPTION
I recently opened an AWS Support ticket as I was running into issues generating a valid Task step for my State Machine. It was not immediately obvious to me that `PascalCase` was expected in every *nested* field/property in the `Parameters` section instead of just top-level.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.