### PR TITLE
Fix indent for example of map states

### DIFF
--- a/doc_source/input-output-contextobject.md
+++ b/doc_source/input-output-contextobject.md
@@ -146,9 +146,9 @@ Given a state machine with a simple `Map` state, we can inject information from 
     "ExampleMapState": {
       "Type": "Map",
       "Parameters": {
-               "ContextIndex.$": "$$.Map.Item.Index",
-               "ContextValue.$": "$$.Map.Item.Value"
-             },
+        "ContextIndex.$": "$$.Map.Item.Index",
+        "ContextValue.$": "$$.Map.Item.Value"
+      },
       "Iterator": {
          "StartAt": "TestPass",
          "States": {


### PR DESCRIPTION
*Description of changes:*
The `Parameters` attribute had an over-indented body.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
