### PR TITLE
Fix example for ResultSelector in input-output-inputpath-params.md

### DIFF
--- a/doc_source/input-output-inputpath-params.md
+++ b/doc_source/input-output-inputpath-params.md
@@ -167,7 +167,7 @@ You can then select the `resourceType` and `ClusterId` using `ResultSelector`:
     <some parameters>
   },
   "ResultSelector": {
-    "ClusterId.$": "$.output.ClusterId",
+    "ClusterId.$": "$.ClusterId",
     "ResourceType.$": "$.resourceType"
   },
   "ResultPath": "$.EMROutput",


### PR DESCRIPTION

*Description of changes:*
The selector shouldn't have "$.output" prefix, because the content of the "output" is already in the context. The correct selector is just "$.ClusterId". Verified on real step with EMR cluster creation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
