### PR TITLE
Parameters key was incorrectly indented

### DIFF
--- a/doc_source/connect-parameters.md
+++ b/doc_source/connect-parameters.md
@@ -18,7 +18,7 @@ You can also pass multiple parameters with static JSON\. As a more complete exam
 
 ```
 "Resource": "arn:aws:states:::sns:publish",
-  "Parameters": {
+"Parameters": {
      "TopicArn": "arn:aws:sns:us-east-1:123456789012:myTopic",
      "Message": "test message",
      "MessageAttributes": {


### PR DESCRIPTION
back-dent the "Parameters" key as it is a sibling of "Resource"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
